### PR TITLE
feat(api) use the PDK for http error responses

### DIFF
--- a/kong/plugins/kubernetes-sidecar-injector/api.lua
+++ b/kong/plugins/kubernetes-sidecar-injector/api.lua
@@ -63,18 +63,18 @@ return {
   ["/kubernetes-sidecar-injector"] = {
     schema = admissionreviewschema,
     methods = {
-      POST = function(self, _, helpers)
+      POST = function(self)
         local plugin_config = get_plugin_configuration("kubernetes-sidecar-injector")
         -- 404 if plugin not found/enabled
         if not plugin_config then
-          return helpers.responses.send_HTTP_NOT_FOUND()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         -- TODO: only accept JSON?
         local args = self.args.post
         local ok, err = admissionreviewschema:validate(args)
         if not ok then
-          return helpers.responses.send_HTTP_BAD_REQUEST(err)
+          return kong.response.exit(422, { message = err })
         end
 
         local review_request = args.request


### PR DESCRIPTION
Use the pdk instead of the deprecated helpers library.

Now uses the 422 status code instead of a plain 400 for invalid request bodies (see https://www.bennadel.com/blog/2434-http-status-codes-for-invalid-data-400-vs-422.htm )