### PR TITLE
feat(*) add name to the plugin handler to make Kong logs more readable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+UNRELEASED
+
+  - Add `name` to the plugin handler to make Kong logs more readable
+
+
 0.1.0 - 2019-02-13
 
   - Initial release

--- a/kong/plugins/kubernetes-sidecar-injector/handler.lua
+++ b/kong/plugins/kubernetes-sidecar-injector/handler.lua
@@ -7,4 +7,8 @@ Handler.VERSION = "0.1.0"
 -- priority doesn't matter, just need to pick something unique for kong tests
 Handler.PRIORITY = 1006
 
+function Handler:new()
+  Handler.super.new(self, "kubernetes-sidecar-injector")
+end
+
 return Handler


### PR DESCRIPTION
### Summary

Adds `name` for the plugin, so that you get better logging, e.g. currently you see this:
```
2019/02/14 11:49:51 [debug] 92385#0: *1 [lua] base_plugin.lua:13: init_worker(): executing plugin "nil": init_worker
```

And this PR changes that to:
```
2019/02/14 11:49:51 [debug] 92385#0: *1 [lua] base_plugin.lua:13: init_worker(): executing plugin "kubernetes_sidecar_injector": init_worker
```
