### PR TITLE
refactor(handler) no need to to inherit from BasePlugin anymore

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+UNRELEASED
+
+  - Remove `BasePlugin` dependency (not needed anymore)
+
+
 0.1.1 - 2019-03-11
 
   - Add `name` to the plugin handler to make Kong logs more readable

--- a/kong/plugins/kubernetes-sidecar-injector/handler.lua
+++ b/kong/plugins/kubernetes-sidecar-injector/handler.lua
@@ -1,14 +1,8 @@
-local BasePlugin = require "kong.plugins.base_plugin"
+local Handler = {
+  VERSION = "0.1.1",
+  -- priority doesn't matter, just need to pick something unique for kong tests
+  PRIORITY = 1006,
+}
 
-local Handler = BasePlugin:extend()
-
-Handler.VERSION = "0.1.1"
-
--- priority doesn't matter, just need to pick something unique for kong tests
-Handler.PRIORITY = 1006
-
-function Handler:new()
-  Handler.super.new(self, "kubernetes-sidecar-injector")
-end
 
 return Handler


### PR DESCRIPTION
### Summary

- Remove `BasePlugin` dependency