### PR TITLE
added name for privkey.pem

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ kind: CertificateSigningRequest
 metadata:
   name: kong-control-plane.kong.svc
 spec:
-  request: $(openssl req -new -nodes -batch -subj /CN=kong-control-plane.kong.svc | base64 | tr -d '\n')
+  request: $(openssl req -new -nodes -batch -keyout privkey.pem -subj /CN=kong-control-plane.kong.svc | base64 | tr -d '\n')
   usages:
   - digital signature
   - key encipherment


### PR DESCRIPTION
on OS X, using libressl v2.6.5, needed to provide explicit name for keyout file so that later step referencing privkey.pem would work