### PR TITLE
 fix(schema) add `kind` and `apiVersion` to Pod schema

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ UNRELEASED
   - Fix api to call process_auto_fields on input data before validating,
     that makes the validation more resilient to Kubernetes changes
     (see https://github.com/Kong/kubernetes-sidecar-injector/issues/7)
+  - Fix api with nicer error reporting on object schema errors
 
   - Fix schema by adding `kind` and `apiVersion` to Pod schema
     (see https://github.com/Kong/kubernetes-sidecar-injector/issues/7)

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ UNRELEASED
     that makes the validation more resilient to Kubernetes changes
     (see https://github.com/Kong/kubernetes-sidecar-injector/issues/7)
 
+  - Fix schema by adding `kind` and `apiVersion` to Pod schema
+    (see https://github.com/Kong/kubernetes-sidecar-injector/issues/7)
 
 0.2.0 - 2019-06-07
 

--- a/kong/plugins/kubernetes-sidecar-injector/api.lua
+++ b/kong/plugins/kubernetes-sidecar-injector/api.lua
@@ -5,6 +5,7 @@ local k8s_typedefs = require "kong.plugins.kubernetes-sidecar-injector.typedefs"
 local get_plugin_configuration = require "kong.plugins.kubernetes-sidecar-injector.config".get_plugin_configuration
 
 local tinsert = table.insert
+local tostring = tostring
 local log_info = kong_pdk.log.info
 local encode_base64 = ngx.encode_base64
 
@@ -50,7 +51,8 @@ local admissionreviewschema = Schema.new {
       local object = podschema:process_auto_fields(review_request.object, "select", false)
       local ok, err = podschema:validate(object)
       if not ok then
-        return nil, err
+        local err_t = kong.db.errors:schema_violation({ object = err })
+        return nil, tostring(err_t)
       end
 
       if type(object.spec) ~= "table" then

--- a/kong/plugins/kubernetes-sidecar-injector/typedefs.lua
+++ b/kong/plugins/kubernetes-sidecar-injector/typedefs.lua
@@ -134,6 +134,8 @@ local Pod = Schema.define { type = "record", fields = {
   { metadata = ObjectMeta },
   { spec = PodSpec },
   { status = Status },
+  { kind = { type = "string" } },
+  { apiVersion = { type = "string" } },
 } }
 
 


### PR DESCRIPTION
### Summary

- Adds `kind` and `apiVersion` to `Pod` schema so that it validates correctly, as reported in #7
- Adds nicer error reporting on object schema errors, as suggested in #7