### PR TITLE
feat(schema) add namespace blacklist to prevent injecting in certain ns

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+UNRELEASED
+
+  - Add `namespace_blacklist` to plugin schema with `kube-system`
+    blacklisted by default
+    (see: https://github.com/Kong/kubernetes-sidecar-injector/issues/4)
+
+
 0.2.0 - 2019-06-07
 
   - Remove `BasePlugin` dependency (not needed anymore)

--- a/kong/plugins/kubernetes-sidecar-injector/schema.lua
+++ b/kong/plugins/kubernetes-sidecar-injector/schema.lua
@@ -28,6 +28,8 @@ return {
         { http_port = typedefs.port { default = 8000 } },
         { https_port = typedefs.port { default = 8443 } },
         { stream_port = typedefs.port { default = 7000 } }, -- should match initArgs default
+        { namespace_blacklist = { type = "array", elements = { type = "string" },
+                                  default = { "kube-system" } } },
     } } },
   },
 }


### PR DESCRIPTION
### Summary

Allows to define namespace blacklist with plugin configuration property: `config.namespace_blacklist` that contains an array of namespaces where the plugin will not inject a Kong sidecar.

By default the blacklist contains `kube-system`, so this also fixes issue #4.